### PR TITLE
Improve the description of the Coordinate type

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -6,7 +6,8 @@ import {modulo, toFixed} from './math.js';
 import {padNumber} from './string.js';
 
 /**
- * An array of numbers representing an xy coordinate. Example: `[16, 48]`.
+ * An array of numbers representing an `xy`, `xyz` or `xyzm` coordinate.
+ * Example: `[16, 48]`.
  * @typedef {Array<number>} Coordinate
  * @api
  */


### PR DESCRIPTION
As discussed previously in #9122, #14166 and partially #14167, coordinates can have more that two dimensions. Not including this possibility in the description is misleading and makes it seem like the `Array<number>` type is incorrect. (Which it actually is, but not in such a blatant way.)